### PR TITLE
Implement parallel test Runner with detailed reporting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ $ pip3 install -r requirements.txt
 
 Dependencies are:
 
-- `ansicolors` for stripping color codes from the output
-- `ruamel.yaml` for parsing the test's YAML metadata
+-   `ansicolors` for stripping color codes from the output
+-   `ruamel.yaml` for parsing the test's YAML metadata
+-   `tqdm` for displaying a progress bar
 
 ## Usage
 

--- a/main.py
+++ b/main.py
@@ -40,11 +40,11 @@ load('{test_file_path}');
 
 
 class TestResult(Enum):
+    SUCCESS = auto()
+    FAILURE = auto()
     METADATA_ERROR = auto()
     LOAD_ERROR = auto()
     TIMEOUT_ERROR = auto()
-    SUCCESS = auto()
-    FAILURE = auto()
     RUNNER_EXCEPTION = auto()
 
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 import concurrent.futures
 import datetime
 import multiprocessing
+import os
 import re
 import shlex
+import signal
 import subprocess
 import traceback
 from argparse import ArgumentParser
@@ -313,4 +315,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    os.setpgrp()
+    try:
+        main()
+    except KeyboardInterrupt:
+        os.killpg(0, signal.SIGKILL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansicolors
 ruamel.yaml
+tqdm


### PR DESCRIPTION
This adds the Runner class which executes the tests in parallel.

Number of workers defaults to the number of cores on the system but
can be changed with -c.

The Runner features a real-time progress bar to indicate its progress.

The Runner collects all the outcomes in a nested dict and reports them 
summed up for each directory in the tests tree. Directories with 0 tests
passed are not expanded.

![image](https://user-images.githubusercontent.com/198496/119737079-05102400-be7f-11eb-998a-82f0e1a54aef.png)
