### PR TITLE
Strip invalid UTF-8 code points from test runner subprocess output

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,6 +135,7 @@ def run_script(
             text=True,
             timeout=timeout,
             preexec_fn=limit_memory,
+            errors="ignore",  # strip invalid utf8 code points instead of throwing (to allow for invalid utf-8 tests)
         )
 
 


### PR DESCRIPTION
This eliminates all (16) cases of a test failing due to a runner exception :snake: 