### PR TITLE
Replace (ab)use of js(1) with a custom LibJS test262 runner

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+Language: Cpp
+BasedOnStyle: WebKit
+SpaceAfterTemplateKeyword: false
+AlignEscapedNewlines: true
+AlignTrailingComments: true
+BreakBeforeInheritanceComma: true
+BreakConstructorInitializers: BeforeComma
+IndentPPDirectives: AfterHash
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterFunction: true
+NamespaceIndentation: None

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ cython_debug/
 # libjs-test262
 serenity/
 test262/
+Build/
 
 # PyCharm
 .idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.16)
+project(libjs-test262 CXX)
+
+if (NOT DEFINED ENV{SERENITY_SOURCE_DIR})
+    message(FATAL_ERROR "SERENITY_SOURCE_DIR not set.")
+endif()
+
+get_filename_component(SERENITY_SOURCE_DIR $ENV{SERENITY_SOURCE_DIR} ABSOLUTE)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Copied from Serenity's root CMakeLists.txt
+add_compile_options(-Wall)
+add_compile_options(-Wextra)
+add_compile_options(-Wno-address-of-packed-member)
+add_compile_options(-Wcast-align)
+add_compile_options(-Wcast-qual)
+add_compile_options(-Wno-deprecated-copy)
+add_compile_options(-Wduplicated-cond)
+add_compile_options(-Wdouble-promotion)
+add_compile_options(-Wno-expansion-to-defined)
+add_compile_options(-Wformat=2)
+add_compile_options(-Wimplicit-fallthrough)
+add_compile_options(-Wno-literal-suffix)
+add_compile_options(-Wlogical-op)
+add_compile_options(-Wmisleading-indentation)
+add_compile_options(-Wmissing-declarations)
+add_compile_options(-Wno-nonnull-compare)
+add_compile_options(-Wnon-virtual-dtor)
+add_compile_options(-Wno-unknown-warning-option)
+add_compile_options(-Wundef)
+add_compile_options(-Wunused)
+add_compile_options(-Wwrite-strings)
+add_compile_options(-fno-exceptions)
+
+set(SERENITY_LIBRARIES_DIR ${SERENITY_SOURCE_DIR}/Userland/Libraries)
+
+# FIXME: I have not idea how to CMake :^)
+if(EXISTS ${SERENITY_SOURCE_DIR}/Build/lagom/libLagom.a)
+    # Lagom-only build with cmake ../../Meta/Lagom
+    set(LIBLAGOM_PATH ${SERENITY_SOURCE_DIR}/Build/lagom/libLagom.a)
+elseif(EXISTS ${SERENITY_SOURCE_DIR}/Build/lagom/Meta/Lagom/libLagom.a)
+    # Full build with cmake ../..
+    set(LIBLAGOM_PATH ${SERENITY_SOURCE_DIR}/Build/lagom/Meta/Lagom/libLagom.a)
+else()
+    message(FATAL_ERROR "libLagom.a not found!")
+endif()
+
+set(SOURCES
+    src/$262Object.cpp
+    src/AgentObject.cpp
+    src/GlobalObject.cpp
+    src/main.cpp
+)
+
+add_executable(libjs-test262-runner ${SOURCES})
+target_include_directories(libjs-test262-runner
+    PUBLIC ${SERENITY_SOURCE_DIR}
+    PUBLIC ${SERENITY_LIBRARIES_DIR}
+)
+target_link_libraries(libjs-test262-runner pthread ${LIBLAGOM_PATH})

--- a/README.md
+++ b/README.md
@@ -14,22 +14,28 @@ pip3 install -r requirements.txt
 
 Dependencies are:
 
-- `ansicolors` for stripping color codes from the output
 - `ruamel.yaml` for parsing the test's YAML metadata
 - `tqdm` for displaying a progress bar
 
 ## Usage
 
-To clone test262, clone SerenityOS and build `js` (standalone as part of Lagom), run:
+To clone test262, clone SerenityOS, build Lagom, and build `libjs-test262-runner`, run:
 
 ```console
 ./setup.sh
 ```
 
-If this succeeds, run:
+The repositories will only be cloned if they don't exist yet locally, so you
+can use this script for development of the test runner as well.
+
+If `SERENITY_SOURCE_DIR` is set, it will be used instead. However, if the Lagom
+build directory already exists, the script will not touch your build in that
+case, so you'll need to build `libLagom.a` yourself.
+
+Once that's done, run:
 
 ```console
-python3 main.py --js ./serenity/Build/js --test262 ./test262/
+python3 main.py --libjs-test262-runner ./Build/libjs-test262-runner --test262-root ./test262/
 ```
 
 ## Options
@@ -41,8 +47,9 @@ Run the test262 ECMAScript test suite with SerenityOS's LibJS
 
 optional arguments:
   -h, --help            show this help message and exit
-  -j PATH, --js PATH    path to the SerenityOS Lagom 'js' binary
-  -t PATH, --test262 PATH
+  -j PATH, --libjs-test262-runner PATH
+                        path to the 'libjs-test262-runner' binary
+  -t PATH, --test262-root PATH
                         path to the 'test262' directory
   -p PATTERN, --pattern PATTERN
                         glob pattern used for test file searching (defaults to test/**/*.js)
@@ -59,10 +66,10 @@ optional arguments:
 ## Current status
 
 Various tests run to completion and yield correct results. However some
-required functionality is not implemented yet, namely the `flags`
-metadata value is completely ignored, meaning asynchronous tests (e.g.
-`Promise`) as well as strict mode/non-strict mode tests will currently
-lead to false positives or false negatives.
+required functionality is not implemented yet, namely the `flags` metadata
+value is completely ignored, meaning asynchronous tests (e.g. `Promise`) as
+well as strict mode/non-strict mode tests will currently lead to false
+positives or false negatives.
 
 Few of the test harness files do not parse yet or generate runtime errors.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-ansicolors
 ruamel.yaml
 tqdm

--- a/setup.sh
+++ b/setup.sh
@@ -1,21 +1,56 @@
 #!/usr/bin/env sh
 
-printf "Removing cloned serenity repo... "
-rm -rf serenity
-printf "done\n"
+SERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR:-serenity}"
+TEST262_SOURCE_DIR="${TEST262_SOURCE_DIR:-test262}"
+LAGOM_BUILD_DIR="${SERENITY_SOURCE_DIR}/Build/lagom"
+# Lagom-only build with cmake ../../Meta/Lagom
+LAGOM_STATIC_LIB_1="${LAGOM_BUILD_DIR}/libLagom.a"
+# Full build with cmake ../..
+LAGOM_STATIC_LIB_2="${LAGOM_BUILD_DIR}/Meta/Lagom/libLagom.a"
+LIBJS_TEST262_BUILD_DIR="Build"
 
-printf "Removing cloned test262 repo... "
-rm -rf test262
-printf "done\n"
+log() {
+    echo -e "\033[0;34m[${1}]\033[0m ${2}"
+}
 
-git clone --depth 1 https://github.com/SerenityOS/serenity.git
-git clone --depth 1 https://github.com/tc39/test262.git
+if [[ ! -d "${SERENITY_SOURCE_DIR}" ]]; then
+    log serenity "Source directory not found, cloning repository"
+    git clone --depth 1 https://github.com/SerenityOS/serenity.git
+fi
 
-mkdir -p serenity/Build
-cd serenity/Build
+if [[ ! -d "${TEST262_SOURCE_DIR}" ]]; then
+    log test262 "Source directory not found, cloning repository"
+    git clone --depth 1 https://github.com/tc39/test262.git
+fi
 
-printf "Running CMake...\n"
-cmake -GNinja -DBUILD_LAGOM=ON ../Meta/Lagom
+if [[ -d "${LAGOM_BUILD_DIR}" ]]; then
+    # If you got your own serenity source tree and build, we're not going to mess with it.
+    if [[ -f "${LAGOM_STATIC_LIB_1}" ]]; then
+        log Lagom "Using existing Lagom build at ${LAGOM_STATIC_LIB_1}"
+    elif [[ -f "${LAGOM_STATIC_LIB_2}" ]]; then
+        log Lagom "Using existing Lagom build at ${LAGOM_STATIC_LIB_2}"
+    else
+        # We can warn you if libLagom.a does not exist, though.
+        log Lagom "ERROR: The Lagom build directory already exists but libLagom.a wasn't found, build it first!"
+        exit 1
+    fi
+else
+    mkdir -p "${LAGOM_BUILD_DIR}"
+    pushd "${LAGOM_BUILD_DIR}"
+        log Lagom "Running CMake..."
+        cmake -GNinja -DBUILD_LAGOM=ON ../../Meta/Lagom
 
-printf "Building Lagom js...\n"
-ninja js_lagom
+        log Lagom "Building..."
+        ninja libLagom.a
+    popd
+fi
+
+mkdir -p "${LIBJS_TEST262_BUILD_DIR}"
+pushd "${LIBJS_TEST262_BUILD_DIR}"
+    log libjs-test262-runner "Running CMake..."
+    export SERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR}"
+    cmake -GNinja ..
+
+    log libjs-test262-runner "Building..."
+    ninja libjs-test262-runner
+popd

--- a/src/$262Object.cpp
+++ b/src/$262Object.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "$262Object.h"
+#include "AgentObject.h"
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Lexer.h>
+#include <LibJS/Parser.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+
+$262Object::$262Object(JS::GlobalObject& global_object)
+    : JS::Object(JS::Object::ConstructWithoutPrototypeTag::Tag, global_object)
+{
+}
+
+void $262Object::initialize(JS::GlobalObject& global_object)
+{
+    Base::initialize(global_object);
+
+    m_agent = vm().heap().allocate<AgentObject>(global_object, global_object);
+
+    define_native_function("evalScript", eval_script, 1);
+    define_property("gc", global_object.get("gc"));
+    define_property("global", this);
+    // TODO: createRealm
+    // TODO: detachArrayBuffer
+}
+
+void $262Object::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_agent);
+}
+
+JS_DEFINE_NATIVE_FUNCTION($262Object::eval_script)
+{
+    auto source = vm.argument(0).to_string(global_object);
+    if (vm.exception())
+        return {};
+    auto parser = JS::Parser(JS::Lexer(source));
+    auto program = parser.parse_program();
+    if (parser.has_errors()) {
+        vm.throw_exception<JS::SyntaxError>(global_object, parser.errors()[0].to_string());
+        return {};
+    }
+    vm.interpreter().run(global_object, *program);
+    if (vm.exception())
+        return {};
+    return JS::js_undefined();
+}

--- a/src/$262Object.h
+++ b/src/$262Object.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "AgentObject.h"
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+
+class $262Object final : public JS::Object {
+    JS_OBJECT($262Object, JS::Object);
+
+public:
+    $262Object(JS::GlobalObject&);
+    virtual void initialize(JS::GlobalObject&) override;
+    virtual ~$262Object() override = default;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    AgentObject* m_agent { nullptr };
+
+    JS_DECLARE_NATIVE_FUNCTION(eval_script);
+};

--- a/src/AgentObject.cpp
+++ b/src/AgentObject.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "AgentObject.h"
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+#include <chrono>
+#include <unistd.h>
+
+AgentObject::AgentObject(JS::GlobalObject& global_object)
+    : JS::Object(JS::Object::ConstructWithoutPrototypeTag::Tag, global_object)
+{
+}
+
+void AgentObject::initialize(JS::GlobalObject& global_object)
+{
+    Base::initialize(global_object);
+
+    define_native_function("monotonicNow", monotonic_now, 0);
+    define_native_function("sleep", sleep, 1);
+    // TODO: broadcast
+    // TODO: getReport
+    // TODO: start
+}
+
+JS_DEFINE_NATIVE_FUNCTION(AgentObject::monotonic_now)
+{
+    auto time_since_epoch = std::chrono::system_clock::now().time_since_epoch();
+    auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(time_since_epoch).count();
+    return JS::Value(static_cast<double>(milliseconds));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(AgentObject::sleep)
+{
+    auto milliseconds = vm.argument(0).to_i32(global_object);
+    if (vm.exception())
+        return {};
+    ::usleep(milliseconds * 1000);
+    return JS::js_undefined();
+}

--- a/src/AgentObject.h
+++ b/src/AgentObject.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+
+class AgentObject final : public JS::Object {
+    JS_OBJECT(AgentObject, JS::Object);
+
+public:
+    AgentObject(JS::GlobalObject&);
+    virtual void initialize(JS::GlobalObject&) override;
+    virtual ~AgentObject() override = default;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(monotonic_now);
+    JS_DECLARE_NATIVE_FUNCTION(sleep);
+};

--- a/src/GlobalObject.cpp
+++ b/src/GlobalObject.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "GlobalObject.h"
+#include "$262Object.h"
+#include "AgentObject.h"
+#include <AK/Format.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/VM.h>
+
+void GlobalObject::initialize_global_object()
+{
+    Base::initialize_global_object();
+
+    m_$262 = vm().heap().allocate<$262Object>(*this, *this);
+
+    // https://github.com/tc39/test262/blob/master/INTERPRETING.md#host-defined-functions
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
+    define_native_function("print", print, 1, attr);
+    define_property("$262", m_$262, attr);
+}
+
+void GlobalObject::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_$262);
+}
+
+JS_DEFINE_NATIVE_FUNCTION(GlobalObject::print)
+{
+    auto string = vm.argument(0).to_string(global_object);
+    if (vm.exception())
+        return {};
+    outln("{}", string);
+    return JS::js_undefined();
+}

--- a/src/GlobalObject.h
+++ b/src/GlobalObject.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "$262Object.h"
+#include <LibJS/Runtime/GlobalObject.h>
+
+class GlobalObject final : public JS::GlobalObject {
+    JS_OBJECT(GlobalObject, JS::GlobalObject);
+
+public:
+    GlobalObject() = default;
+    virtual void initialize_global_object() override;
+    virtual ~GlobalObject() override = default;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    $262Object* m_$262 { nullptr };
+
+    JS_DECLARE_NATIVE_FUNCTION(print);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "GlobalObject.h"
+#include <AK/Format.h>
+#include <AK/JsonObject.h>
+#include <AK/Result.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Lexer.h>
+#include <LibJS/Parser.h>
+#include <LibJS/Runtime/VM.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static Result<ByteBuffer, JsonObject> read_file(String const& path)
+{
+    if (path.is_null()) {
+        auto file = Core::File::standard_input();
+        return file->read_all();
+    } else {
+        auto file = Core::File::construct(path);
+        if (!file->open(Core::OpenMode::ReadOnly)) {
+            JsonObject error_object;
+            error_object.set("details", String::formatted("Failed to open '{}': {}", path, file->error_string()));
+            return error_object;
+        }
+        return file->read_all();
+    }
+}
+
+static Result<NonnullRefPtr<JS::Program>, JsonObject> parse_program(StringView source)
+{
+    auto parser = JS::Parser(JS::Lexer(source));
+    auto program = parser.parse_program();
+    if (parser.has_errors()) {
+        JsonObject error_object;
+        error_object.set("phase", "parse");
+        error_object.set("type", "SyntaxError");
+        error_object.set("details", parser.errors()[0].to_string());
+        return error_object;
+    }
+    return program;
+}
+
+static Result<void, JsonObject> run_program(JS::Interpreter& interpreter, JS::Program const& program)
+{
+    auto& vm = interpreter.vm();
+    interpreter.run(interpreter.global_object(), program);
+    if (auto* exception = vm.exception()) {
+        vm.clear_exception();
+        JsonObject error_object;
+        error_object.set("phase", "runtime");
+        if (exception->value().is_object()) {
+            auto& object = exception->value().as_object();
+
+            auto name = object.get_without_side_effects("name");
+            if (!name.is_empty() && !name.is_accessor() && !name.is_native_property()) {
+                error_object.set("type", name.to_string_without_side_effects());
+            } else {
+                auto constructor = object.get_without_side_effects("constructor");
+                if (constructor.is_object()) {
+                    // NOTE: Would be nice to use get_without_side_effects() here, but for
+                    // whatever reason ScriptFunction's .name and .length are currently
+                    // native properties, so that's not going to work.
+                    name = constructor.as_object().get("name");
+                    if (!name.is_empty())
+                        error_object.set("type", name.to_string_without_side_effects());
+                }
+            }
+
+            auto message = object.get_without_side_effects("message");
+            if (!message.is_empty() && !message.is_accessor() && !message.is_native_property())
+                error_object.set("details", message.to_string_without_side_effects());
+        }
+        if (!error_object.has("type"))
+            error_object.set("type", exception->value().to_string_without_side_effects());
+        return error_object;
+    }
+    return {};
+}
+
+static Result<void, JsonObject> run_script(String const& path, JS::Interpreter& interpreter)
+{
+    auto source_or_error = read_file(path);
+    if (source_or_error.is_error())
+        return source_or_error.release_error();
+    auto source = source_or_error.release_value();
+
+    auto program_or_error = parse_program(source);
+    if (program_or_error.is_error())
+        return program_or_error.release_error();
+    auto program = program_or_error.release_value();
+
+    return run_program(interpreter, *program);
+}
+
+int main(int argc, char** argv)
+{
+    Vector<String> harness_files;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("LibJS test262 runner for individual tests");
+    args_parser.add_positional_argument(harness_files, "Harness files to execute prior to test execution", "paths", Core::ArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
+    // All the piping stuff is based on https://stackoverflow.com/a/956269.
+
+    constexpr auto BUFFER_SIZE = 1 * KiB;
+    char buffer[BUFFER_SIZE] = {};
+
+    auto saved_stdout = dup(STDOUT_FILENO);
+    if (saved_stdout < 0) {
+        perror("dup");
+        return 1;
+    }
+
+    int stdout_pipe[2];
+    if (pipe(stdout_pipe) < 0) {
+        perror("pipe");
+        return 1;
+    }
+
+    auto flags = fcntl(stdout_pipe[0], F_GETFL);
+    flags |= O_NONBLOCK;
+    fcntl(stdout_pipe[0], F_SETFL, flags);
+
+    if (dup2(stdout_pipe[1], STDOUT_FILENO) < 0) {
+        perror("dup2");
+        return 1;
+    }
+    if (close(stdout_pipe[1]) < 0) {
+        perror("close");
+        return 1;
+    }
+
+    auto vm = JS::VM::create();
+    auto interpreter = JS::Interpreter::create<GlobalObject>(*vm);
+
+    JsonObject result_object;
+
+    for (auto& path : harness_files) {
+        auto result = run_script(path, *interpreter);
+        if (result.is_error()) {
+            result_object.set("harness_error", true);
+            result_object.set("harness_file", path);
+            result_object.set("error", result.release_error());
+            break;
+        }
+    }
+    if (!result_object.has("harness_error")) {
+        auto result = run_script({}, *interpreter);
+        if (result.is_error())
+            result_object.set("error", result.release_error());
+    }
+
+    fflush(stdout);
+    auto nread = read(stdout_pipe[0], buffer, BUFFER_SIZE);
+    if (dup2(saved_stdout, STDOUT_FILENO) < 0) {
+        perror("dup2");
+        return 1;
+    }
+    if (close(stdout_pipe[0]) < 0) {
+        perror("close");
+        return 1;
+    }
+
+    if (nread > 0)
+        result_object.set("output", String { buffer, static_cast<size_t>(nread) });
+
+    outln("{}", result_object.to_string());
+    return 0;
+}


### PR DESCRIPTION
Current results (+12!):

```
Old: 17724/40997 ( 43.23%) [ ✅ 17724 ❌ 22346 ⚠️ 35    📄 2     ⚙️ 125   💀 16    💥️ 749   ]
New: 17736/40997 ( 43.26%) [ ✅ 17736 ❌ 22334 ⚠️ 35    📄 2     ⚙️ 125   💀 16    💥️ 749   ]

✅ = SUCCESS, ❌ = FAILURE, ⚠️ = SKIPPED, 📄 = METADATA_ERROR, ⚙️ = HARNESS_ERROR, 💀 = TIMEOUT_ERROR, 💥️ = PROCESS_ERROR, 🐍 = RUNNER_EXCEPTION
```

cc @nooga @IdanHo