### PR TITLE
Replace the bourne shell shebang with a bash one in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 SERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR:-serenity}"
 TEST262_SOURCE_DIR="${TEST262_SOURCE_DIR:-test262}"


### PR DESCRIPTION
The `[[` operator is a bash-only builtin.