### PR TITLE
main: Make runner script executable

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
 # Copyright (c) 2021, Marcin Gasperowicz <xnooga@gmail.com>
 # Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>

--- a/run_all_and_update_results.py
+++ b/run_all_and_update_results.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
 #
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
This allows us to drop the `python' prefix.