### PR TITLE
Add the forgotten 'duration' entry to the bytecode results

### DIFF
--- a/run_all_and_update_results.py
+++ b/run_all_and_update_results.py
@@ -167,6 +167,7 @@ def main() -> None:
                 },
             },
             "test262-bytecode": {
+                "duration": libjs_test262_bc_output["duration"],
                 "results": {
                     "total": libjs_test262_bc_output["results"]["test"]["count"],
                     "passed": libjs_test262_bc_results["PASSED"],


### PR DESCRIPTION
Sowwy :(
I'm not sure what to do with the data that will be generated by the currently running PR though, should I patch that up?