### PR TITLE
Revert "Increase concurrency in CI if the MAX_RUNNER_THREADS env variable is available"

### DIFF
--- a/run_all_and_update_results.py
+++ b/run_all_and_update_results.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import os
 import shlex
 import subprocess
 import sys
@@ -119,13 +118,6 @@ def main() -> None:
     )
     test_js_results = test_js_output["results"]["tests"]
 
-    try:
-        runner_threads = int(os.environ["MAX_RUNNER_THREADS"])
-    except (KeyError, ValueError):
-        concurrency = ""
-    else:
-        concurrency = f"--concurrency {runner_threads * 2} "
-
     print("Running test262 with the AST interpreter...")
     libjs_test262_output = json.loads(
         # This is not the way, but I can't be bothered to import this stuff. :^)
@@ -133,7 +125,6 @@ def main() -> None:
             f"python3 {libjs_test262_main_py} "
             f"--libjs-test262-runner {libjs_test262_runner} "
             f"--test262 {test262} "
-            f"{concurrency}"
             "--silent --json"
         )
     )
@@ -146,7 +137,6 @@ def main() -> None:
             f"python3 {libjs_test262_main_py} "
             f"--libjs-test262-runner {libjs_test262_runner} "
             f"--test262 {test262} "
-            f"{concurrency}"
             "--silent --json --use-bytecode"
         )
     )


### PR DESCRIPTION
Reverts linusg/libjs-test262#25

Looks like this affected performance negatively (+1.5 minutes), and barely increased core saturation, so just reverting it for now is probably the best.

I think that the real way to get more perf and increase saturation is reduce the amount of process creation and tear down. (Since we do that once for every test file right now)