### PR TITLE
Use the new define_direct_property helper method

### DIFF
--- a/src/$262Object.cpp
+++ b/src/$262Object.cpp
@@ -29,15 +29,16 @@ void $262Object::initialize(JS::GlobalObject& global_object)
     m_agent = vm().heap().allocate<AgentObject>(global_object, global_object);
     m_is_htmldda = vm().heap().allocate<IsHTMLDDA>(global_object, global_object);
 
-    define_native_function("clearKeptObjects", clear_kept_objects, 0);
-    define_native_function("createRealm", create_realm, 0);
-    define_native_function("detachArrayBuffer", detach_array_buffer, 1);
-    define_native_function("evalScript", eval_script, 1);
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
+    define_native_function("clearKeptObjects", clear_kept_objects, 0, attr);
+    define_native_function("createRealm", create_realm, 0, attr);
+    define_native_function("detachArrayBuffer", detach_array_buffer, 1, attr);
+    define_native_function("evalScript", eval_script, 1, attr);
 
-    define_property("agent", m_agent);
-    define_property("gc", global_object.get("gc"));
-    define_property("global", &global_object);
-    define_property("IsHTMLDDA", m_is_htmldda);
+    define_direct_property("agent", m_agent, attr);
+    define_direct_property("gc", global_object.get("gc"), attr);
+    define_direct_property("global", &global_object, attr);
+    define_direct_property("IsHTMLDDA", m_is_htmldda, attr);
 }
 
 void $262Object::visit_edges(JS::Cell::Visitor& visitor)

--- a/src/AgentObject.cpp
+++ b/src/AgentObject.cpp
@@ -19,8 +19,9 @@ void AgentObject::initialize(JS::GlobalObject& global_object)
 {
     Base::initialize(global_object);
 
-    define_native_function("monotonicNow", monotonic_now, 0);
-    define_native_function("sleep", sleep, 1);
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
+    define_native_function("monotonicNow", monotonic_now, 0, attr);
+    define_native_function("sleep", sleep, 1, attr);
     // TODO: broadcast
     // TODO: getReport
     // TODO: start

--- a/src/GlobalObject.cpp
+++ b/src/GlobalObject.cpp
@@ -21,7 +21,7 @@ void GlobalObject::initialize_global_object()
     // https://github.com/tc39/test262/blob/master/INTERPRETING.md#host-defined-functions
     u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
     define_native_function("print", print, 1, attr);
-    define_property("$262", m_$262, attr);
+    define_direct_property("$262", m_$262, attr);
 }
 
 void GlobalObject::visit_edges(JS::Cell::Visitor& visitor)


### PR DESCRIPTION
The old define_property helper method was removed.

If possible this should be merged just before the accompanying PR in Serenity is merged.