### PR TITLE
Build: Convert to super build that relies on Lagom shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,18 @@
 cmake_minimum_required(VERSION 3.16)
 project(libjs-test262 CXX)
 
-if (NOT DEFINED ENV{SERENITY_SOURCE_DIR})
-    message(FATAL_ERROR "SERENITY_SOURCE_DIR not set.")
-endif()
-
-get_filename_component(SERENITY_SOURCE_DIR $ENV{SERENITY_SOURCE_DIR} ABSOLUTE)
-
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+# See slide 100 of the following ppt :^)
+# https://crascit.com/wp-content/uploads/2019/09/Deep-CMake-For-Library-Authors-Craig-Scott-CppCon-2019.pdf
+if (NOT APPLE)
+    set(CMAKE_INSTALL_RPATH $ORIGIN)
+endif()
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Copied from Serenity's root CMakeLists.txt
 add_compile_options(-Wall)
@@ -35,18 +38,10 @@ add_compile_options(-Wunused)
 add_compile_options(-Wwrite-strings)
 add_compile_options(-fno-exceptions)
 
-set(SERENITY_LIBRARIES_DIR ${SERENITY_SOURCE_DIR}/Userland/Libraries)
+include (FetchContent)
+include (cmake/FetchLagom.cmake)
 
-# FIXME: I have not idea how to CMake :^)
-if(EXISTS ${SERENITY_SOURCE_DIR}/Build/lagom/libLagom.a)
-    # Lagom-only build with cmake ../../Meta/Lagom
-    set(LIBLAGOM_PATH ${SERENITY_SOURCE_DIR}/Build/lagom/libLagom.a)
-elseif(EXISTS ${SERENITY_SOURCE_DIR}/Build/lagom/Meta/Lagom/libLagom.a)
-    # Full build with cmake ../..
-    set(LIBLAGOM_PATH ${SERENITY_SOURCE_DIR}/Build/lagom/Meta/Lagom/libLagom.a)
-else()
-    message(FATAL_ERROR "libLagom.a not found!")
-endif()
+find_package(Threads REQUIRED)
 
 set(SOURCES
     src/$262Object.cpp
@@ -57,8 +52,5 @@ set(SOURCES
 )
 
 add_executable(libjs-test262-runner ${SOURCES})
-target_include_directories(libjs-test262-runner
-    PUBLIC ${SERENITY_SOURCE_DIR}
-    PUBLIC ${SERENITY_LIBRARIES_DIR}
-)
-target_link_libraries(libjs-test262-runner pthread ${LIBLAGOM_PATH})
+target_link_libraries(libjs-test262-runner Threads::Threads Lagom::Core Lagom::JS)
+install(TARGETS libjs-test262-runner RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/cmake/FetchLagom.cmake
+++ b/cmake/FetchLagom.cmake
@@ -1,0 +1,33 @@
+# Copyright (c) 2021, Andrew Kaster <akaster@serenityos.org>
+#
+# SPDX-License-Identifier: MIT
+
+# Fetch serenity, so that we can build Lagom from it
+FetchContent_Declare(lagom
+    GIT_REPOSITORY https://github.com/SerenityOS/serenity.git
+    GIT_TAG origin/master
+    GIT_SHALLOW TRUE
+    SOURCE_DIR serenity
+)
+
+# Allow developers to skip download/update steps with local checkout
+if (SERENITY_SOURCE_DIR)
+    set(FETCHCONTENT_SOURCE_DIR_LAGOM ${SERENITY_SOURCE_DIR} CACHE PATH "Developer's pre-existing serenity source directory" FORCE)
+    message(STATUS "Using pre-existing SERENITY_SOURCE_DIR: ${SERENITY_SOURCE_DIR}")
+endif()
+
+# Can't use FetchContent_MakeAvailable b/c we want to use the Lagom build, not the main build
+# Populate source directory for lagom
+FetchContent_GetProperties(lagom)
+if (NOT lagom_POPULATED)
+    FetchContent_Populate(lagom)
+    set(BUILD_LAGOM ON)
+
+    # FIXME: Setting target_include_directories on Lagom libraries might make this unecessary?
+    include_directories(${lagom_SOURCE_DIR}/Userland/Libraries)
+    include_directories(${lagom_SOURCE_DIR})
+    include_directories(${lagom_BINARY_DIR})
+
+    # We set EXCLUDE_FROM_ALL to make sure that only required Lagom libraries are built
+    add_subdirectory(${lagom_SOURCE_DIR}/Meta/Lagom ${lagom_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/setup.sh
+++ b/setup.sh
@@ -1,56 +1,21 @@
 #!/usr/bin/env bash
-
-SERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR:-serenity}"
 TEST262_SOURCE_DIR="${TEST262_SOURCE_DIR:-test262}"
-LAGOM_BUILD_DIR="${SERENITY_SOURCE_DIR}/Build/lagom"
-# Lagom-only build with cmake ../../Meta/Lagom
-LAGOM_STATIC_LIB_1="${LAGOM_BUILD_DIR}/libLagom.a"
-# Full build with cmake ../..
-LAGOM_STATIC_LIB_2="${LAGOM_BUILD_DIR}/Meta/Lagom/libLagom.a"
 LIBJS_TEST262_BUILD_DIR="Build"
 
 log() {
     echo -e "\033[0;34m[${1}]\033[0m ${2}"
 }
 
-if [[ ! -d "${SERENITY_SOURCE_DIR}" ]]; then
-    log serenity "Source directory not found, cloning repository"
-    git clone --depth 1 https://github.com/SerenityOS/serenity.git
-fi
-
 if [[ ! -d "${TEST262_SOURCE_DIR}" ]]; then
     log test262 "Source directory not found, cloning repository"
     git clone --depth 1 https://github.com/tc39/test262.git
 fi
 
-if [[ -d "${LAGOM_BUILD_DIR}" ]]; then
-    # If you got your own serenity source tree and build, we're not going to mess with it.
-    if [[ -f "${LAGOM_STATIC_LIB_1}" ]]; then
-        log Lagom "Using existing Lagom build at ${LAGOM_STATIC_LIB_1}"
-    elif [[ -f "${LAGOM_STATIC_LIB_2}" ]]; then
-        log Lagom "Using existing Lagom build at ${LAGOM_STATIC_LIB_2}"
-    else
-        # We can warn you if libLagom.a does not exist, though.
-        log Lagom "ERROR: The Lagom build directory already exists but libLagom.a wasn't found, build it first!"
-        exit 1
-    fi
-else
-    mkdir -p "${LAGOM_BUILD_DIR}"
-    pushd "${LAGOM_BUILD_DIR}"
-        log Lagom "Running CMake..."
-        cmake -GNinja -DBUILD_LAGOM=ON ../../Meta/Lagom
-
-        log Lagom "Building..."
-        ninja libLagom.a
-    popd
-fi
-
 mkdir -p "${LIBJS_TEST262_BUILD_DIR}"
 pushd "${LIBJS_TEST262_BUILD_DIR}"
     log libjs-test262-runner "Running CMake..."
-    export SERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR}"
-    cmake -GNinja ..
+    cmake -GNinja .. -DSERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR}"
 
     log libjs-test262-runner "Building..."
-    ninja libjs-test262-runner
+    cmake --build .
 popd


### PR DESCRIPTION
Move the CMake rules for the libjs-test262-runner binary into the source
directory so that the top level can be a super build that relies on
ExternalProject_Add for the Lagom dependency. This allows us to build
with a proper find_package(Lagom REQUIRED) build rule, which just feels
warm and fuzzy.


Based on @sin-ack 's previous PR #18

Requires https://github.com/SerenityOS/serenity/pull/9017