### PR TITLE
Add Serenity's Build directory to libjs-test262-runner's include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,11 @@ set(SERENITY_LIBRARIES_DIR ${SERENITY_SOURCE_DIR}/Userland/Libraries)
 if(EXISTS ${SERENITY_SOURCE_DIR}/Build/lagom/libLagom.a)
     # Lagom-only build with cmake ../../Meta/Lagom
     set(LIBLAGOM_PATH ${SERENITY_SOURCE_DIR}/Build/lagom/libLagom.a)
+    set(SERENITY_BUILD_DIR ${SERENITY_SOURCE_DIR}/Build/lagom)
 elseif(EXISTS ${SERENITY_SOURCE_DIR}/Build/lagom/Meta/Lagom/libLagom.a)
     # Full build with cmake ../..
     set(LIBLAGOM_PATH ${SERENITY_SOURCE_DIR}/Build/lagom/Meta/Lagom/libLagom.a)
+    set(SERENITY_BUILD_DIR ${SERENITY_SOURCE_DIR}/Build/lagom/Meta/Lagom)
 else()
     message(FATAL_ERROR "libLagom.a not found!")
 endif()
@@ -60,5 +62,6 @@ add_executable(libjs-test262-runner ${SOURCES})
 target_include_directories(libjs-test262-runner
     PUBLIC ${SERENITY_SOURCE_DIR}
     PUBLIC ${SERENITY_LIBRARIES_DIR}
+    PUBLIC ${SERENITY_BUILD_DIR}
 )
 target_link_libraries(libjs-test262-runner pthread ${LIBLAGOM_PATH})


### PR DESCRIPTION
If a LibJS header tries to include <AK/Debug.h>, libjs-test262-runner
will currently fail to compile.

```
In file included from /home/flynn/workspace/serenity/Userland/Libraries/LibRegex/Regex.h:10,
                 from /home/flynn/workspace/serenity/Userland/Libraries/LibJS/AST.h:22,
                 from /home/flynn/workspace/serenity/Userland/Libraries/LibJS/Interpreter.h:14,
                 from ../src/main.cpp:19:
/home/flynn/workspace/serenity/Userland/Libraries/LibRegex/RegexDebug.h:11:10: fatal error: AK/Debug.h: No such file or directory
   11 | #include <AK/Debug.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```