### PR TITLE
Build: Build test-js along with the libjs-test262-runner by default

### DIFF
--- a/run_all_and_update_results.py
+++ b/run_all_and_update_results.py
@@ -86,9 +86,11 @@ def main() -> None:
     commit_timestamp = get_git_commit_timestamp(serenity)
     run_timestamp = int(time.time())
 
-    serenity_test_js = serenity / "Build/lagom/test-js"
+    serenity_test_js = libjs_test262 / "Build/_deps/lagom-build/test-js"
     if not serenity_test_js.exists():
-        serenity_test_js = serenity / "Build/lagom/Meta/Lagom/test-js"
+        serenity_test_js = serenity / "Build/lagom/test-js"
+        if not serenity_test_js.exists():
+            serenity_test_js = serenity / "Build/lagom/Meta/Lagom/test-js"
     libjs_test262_main_py = libjs_test262 / "main.py"
     libjs_test262_runner = libjs_test262 / "Build/libjs-test262-runner"
 

--- a/setup.sh
+++ b/setup.sh
@@ -17,5 +17,5 @@ pushd "${LIBJS_TEST262_BUILD_DIR}"
     cmake -GNinja .. -DSERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR}"
 
     log libjs-test262-runner "Building..."
-    cmake --build .
+    cmake --build . --target libjs-test262-runner test-js
 popd


### PR DESCRIPTION
While we have a build context handy that has libjs.so being built from
the user's provided serenity source directory, let's go ahead and build
test-js for the parser tests to use. Set the default path for test-js to
be the FetchContent'd build directory for Lagom as well.