### PR TITLE
CMake: Set BUILD_LAGOM as an internal cache variable

### DIFF
--- a/cmake/FetchLagom.cmake
+++ b/cmake/FetchLagom.cmake
@@ -21,7 +21,7 @@ endif()
 FetchContent_GetProperties(lagom)
 if (NOT lagom_POPULATED)
     FetchContent_Populate(lagom)
-    set(BUILD_LAGOM ON)
+    set(BUILD_LAGOM ON CACHE INTERNAL "Build all Lagom targets")
 
     # FIXME: Setting target_include_directories on Lagom libraries might make this unecessary?
     include_directories(${lagom_SOURCE_DIR}/Userland/Libraries)


### PR DESCRIPTION
We always want to BUILD_LAGOM. This regressed in serenity commit
https://github.com/SerenityOS/serenity/commit/904a268872416dc9b9f26c83fd0b1bd8b715c511
where BUILD_LAGOM began being set as a cache variable. The impact of
this on the libjs-test262 build is that after BUILD_LAGOM was set to OFF
in the cache, it would be overriden by the normal variable in FetchLagom
but not the first time it gets ran.


cc @alimpfard 