### PR TITLE
Update usage of to_i32() as it now uses ThrowCompletionOr

### DIFF
--- a/src/AgentObject.cpp
+++ b/src/AgentObject.cpp
@@ -36,9 +36,7 @@ JS_DEFINE_NATIVE_FUNCTION(AgentObject::monotonic_now)
 
 JS_DEFINE_NATIVE_FUNCTION(AgentObject::sleep)
 {
-    auto milliseconds = vm.argument(0).to_i32(global_object);
-    if (vm.exception())
-        return {};
+    auto milliseconds = TRY_OR_DISCARD(vm.argument(0).to_i32(global_object));
     ::usleep(milliseconds * 1000);
     return JS::js_undefined();
 }


### PR DESCRIPTION
This got changed in SerenityOS/serenity@f6a5ff7b003930a1994c0f4c4a1c4b1da7c7123d 
But this usage in the runner was forgotten