### PR TITLE
Slightly rework test output and add todo error detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ class TestResult(str, Enum):
     TIMEOUT_ERROR = "TIMEOUT_ERROR"
     PROCESS_ERROR = "PROCESS_ERROR"
     RUNNER_EXCEPTION = "RUNNER_EXCEPTION"
+    TODO_ERROR = "TODO_ERROR"
 
 
 @dataclass
@@ -57,6 +58,7 @@ EMOJIS = {
     TestResult.TIMEOUT_ERROR: "💀",
     TestResult.PROCESS_ERROR: "💥️",
     TestResult.RUNNER_EXCEPTION: "🐍",
+    TestResult.TODO_ERROR: "📝",
 }
 
 NON_FAIL_RESULTS = [TestResult.PASSED, TestResult.SKIPPED]
@@ -188,6 +190,8 @@ def run_tests(
                 test_result_state = TestResult.PASSED
             elif result == "skipped":
                 test_result_state = TestResult.SKIPPED
+            elif result == "todo_error":
+                test_result_state = TestResult.TODO_ERROR
             elif result != "failed":
                 raise Exception(f"Unknown error code: {result} from {test_result}")
 

--- a/run_all_and_update_results.py
+++ b/run_all_and_update_results.py
@@ -166,6 +166,7 @@ def main() -> None:
                     "timeout_error": libjs_test262_results["TIMEOUT_ERROR"],
                     "process_error": libjs_test262_results["PROCESS_ERROR"],
                     "runner_exception": libjs_test262_results["RUNNER_EXCEPTION"],
+                    "todo_error": libjs_test262_results["TODO_ERROR"],
                 },
             },
             "test262-bytecode": {
@@ -180,6 +181,7 @@ def main() -> None:
                     "timeout_error": libjs_test262_bc_results["TIMEOUT_ERROR"],
                     "process_error": libjs_test262_bc_results["PROCESS_ERROR"],
                     "runner_exception": libjs_test262_bc_results["RUNNER_EXCEPTION"],
+                    "todo_error": libjs_test262_bc_results["TODO_ERROR"],
                 },
             },
             "test262-parser-tests": {


### PR DESCRIPTION
The test output now always gives "error" with "got" and "expected" instead of sometimes having some of them.
See also:
https://github.com/SerenityOS/discord-bot/pull/281
https://github.com/linusg/libjs-website/pull/11