### PR TITLE
libjs-test262-runner: Rethrow exception on vm after bytecode run

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,10 @@ static Result<void, TestError> run_program(InterpreterT& interpreter, JS::Progra
         auto unit = JS::Bytecode::Generator::generate(program);
         auto& passes = JS::Bytecode::Interpreter::optimization_pipeline();
         passes.perform(unit);
-        TRY_OR_DISCARD(interpreter.run(unit));
+        auto result = interpreter.run(unit);
+        // Until the AST interpreter gives a completion we just rethrow any exception that was thrown.
+        if (result.is_error())
+            vm.throw_exception(interpreter.global_object(), result.throw_completion().value());
     }
 
     if (auto* exception = vm.exception()) {


### PR DESCRIPTION
See https://github.com/SerenityOS/serenity/pull/10945
(Although they don't need to be merged at the same time.)