### PR TITLE
Everything: Add a lot of convenient options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ python3 main.py --libjs-test262-runner ./Build/libjs-test262-runner --test262-ro
 ## Options
 
 ```text
-usage: main.py [-h] -j PATH [-b] -t PATH [-p PATTERN] [-c CONCURRENCY] [--timeout TIMEOUT] [--memory-limit MEMORY_LIMIT] [--json] [--per-file] [-s | -v] [-f] [--parse-only] [--ignore IGNORE]
+usage: main.py [-h] [-j PATH] [-b] [-t PATH] [-p PATTERN] [-c CONCURRENCY] [--timeout TIMEOUT] [--memory-limit MEMORY_LIMIT] [--json] [--per-file PATH] [-s | -v] [-f] [--parse-only] [--ignore IGNORE] [--forward-stderr] [--summary]
 
 Run the test262 ECMAScript test suite with SerenityOS's LibJS
 
@@ -59,12 +59,14 @@ optional arguments:
   --memory-limit MEMORY_LIMIT
                         memory limit for each test run in megabytes (defaults to 512)
   --json                print the test results as JSON
-  --per-file            show per-file results instead of per-directory results
+  --per-file PATH       output per-file results to file
   -s, --silent          don't print any progress information
   -v, --verbose         print output of test runs
   -f, --fail-only       only show failed tests
   --parse-only          only parse the test files and fail/pass based on that
   --ignore IGNORE       ignore any tests matching the glob
+  --forward-stderr      forward all stderr output to the stderr of the script
+  --summary             only show the top level results
 ```
 
 ## Current status

--- a/per_file_result_diff.py
+++ b/per_file_result_diff.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
 #
 # SPDX-License-Identifier: MIT

--- a/run_all_and_update_results.py
+++ b/run_all_and_update_results.py
@@ -64,6 +64,20 @@ def main() -> None:
         metavar="PATH",
         help="path to the results JSON file",
     )
+    parser.add_argument(
+        "--per-file-output",
+        default=None,
+        type=str,
+        metavar="PATH",
+        help="output the per-file result of the non-bytecode run to this file",
+    )
+    parser.add_argument(
+        "--per-file-bytecode-output",
+        default=None,
+        type=str,
+        metavar="PATH",
+        help="output the per-file result of the bytecode run to this file",
+    )
     args = parser.parse_args()
 
     libjs_test262 = Path(__file__).parent
@@ -127,7 +141,12 @@ def main() -> None:
             f"python3 {libjs_test262_main_py} "
             f"--libjs-test262-runner {libjs_test262_runner} "
             f"--test262 {test262} "
-            "--silent --json"
+            "--silent --summary --json "
+            + (
+                ""
+                if args.per_file_output is None
+                else f"--per-file {args.per_file_output} "
+            )
         )
     )
     libjs_test262_results = libjs_test262_output["results"]["test"]["results"]
@@ -139,7 +158,12 @@ def main() -> None:
             f"python3 {libjs_test262_main_py} "
             f"--libjs-test262-runner {libjs_test262_runner} "
             f"--test262 {test262} "
-            "--silent --json --use-bytecode"
+            "--silent --summary --json --use-bytecode "
+            + (
+                ""
+                if args.per_file_bytecode_output is None
+                else f"--per-file {args.per_file_bytecode_output} "
+            )
         )
     )
     libjs_test262_bc_results = libjs_test262_bc_output["results"]["test"]["results"]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -326,7 +326,10 @@ static Result<TestMetadata, String> extract_metadata(StringView source)
             }
 
             for (auto flag : flags) {
-                if (flag == "noStrict"sv || flag == "raw"sv) {
+                if (flag == "raw"sv) {
+                    metadata.strict_mode = StrictMode::NoStrict;
+                    metadata.harness_files.clear();
+                } else if (flag == "noStrict"sv) {
                     metadata.strict_mode = StrictMode::NoStrict;
                 } else if (flag == "onlyStrict"sv) {
                     metadata.strict_mode = StrictMode::OnlyStrict;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,11 +372,20 @@ static bool verify_test(Result<void, TestError>& result, TestMetadata const& met
         } else if (result.error().phase == NegativePhase::Runtime) {
             auto& error_type = result.error().type;
             auto& error_details = result.error().details;
-            if ((error_type == "InternalError"sv && error_details.starts_with("TODO("))
+            if ((error_type == "InternalError"sv && error_details.starts_with("TODO("sv))
                 || (error_type == "Test262Error"sv && error_details.ends_with(" but got a InternalError"sv))) {
                 output.set("todo_error", true);
                 output.set("result", "todo_error");
             }
+        }
+    }
+
+    if (metadata.is_async && output.has("output"sv)) {
+        auto& output_messages = output.get("output"sv);
+        VERIFY(output_messages.is_string());
+        if (output_messages.as_string().contains("AsyncTestFailure:InternalError: TODO("sv)) {
+            output.set("todo_error", true);
+            output.set("result", "todo_error");
         }
     }
 


### PR DESCRIPTION
To small fixes to the actual runner: 
- Fix test behavior with `raw` flag
- Detect TODO errors thrown within a promise or async function: `Diff Tests: -110 ❌   +110 📝`

Add a couple of options to main:
- `--forward-stderr` forward all the stderr output (cc @ADKaster does this seem useful or is outputting to a file better?)
- `--summary` only output the toplevel results i.e. `test 34983/45156 ( 77.47%) [ ✅ 34983 ❌ 2249  ⚙️ 112   💀 3     💥️ 199   📝 7610  ]` only
- `--per-file` now takes a argument of to which file to output the per-file results this will allow us to expose the current state of master on CI

Add a `-s / --silent` mode for comparing per-files with non the exact same tests. This is something I have been using for a long time by having a master.json file with the full results and then being able to compare any subset of tests against the master file.

Finally add options to `run_all_and_update_results.py` to output the per-file results of non-bytecode and bytecode runs. This is not done by default as that could be dangerous in overwriting files.

Also sorry Linus I forgot most of the python tips/commentsyou had so hope this isn't too bad :grimacing:.