### PR TITLE
Update for Bytecode::Generator::generate() returning NonnullOwnPtr

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,8 +88,8 @@ static Result<void, TestError> run_program(InterpreterT& interpreter, ScriptOrMo
 
         auto unit = JS::Bytecode::Generator::generate(program_node);
         auto& passes = JS::Bytecode::Interpreter::optimization_pipeline();
-        passes.perform(unit);
-        result = interpreter.run(unit);
+        passes.perform(*unit);
+        result = interpreter.run(*unit);
     }
 
     if (result.is_error()) {


### PR DESCRIPTION
Oops, I broke the runner here https://github.com/SerenityOS/serenity/commit/7a742b17da1cc7e53ea272e733a5244c168afc10