### PR TITLE
Update executable paths to follow upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ case, so you'll need to build `libLagom.a` yourself.
 Once that's done, run:
 
 ```console
-python3 main.py --libjs-test262-runner ./Build/_deps/lagom-build/test262-runner --test262-root ./test262/
+python3 main.py --libjs-test262-runner ./Build/_deps/lagom-build/bin/test262-runner --test262-root ./test262/
 ```
 
 ## Options

--- a/run_all_and_update_results.py
+++ b/run_all_and_update_results.py
@@ -30,11 +30,11 @@ def get_git_commit_timestamp(path: Path) -> int:
 
 
 def find_lagom_executable(test262_path: Path, serenity_path: Path, name: str):
-    executable_path = test262_path / f"Build/_deps/lagom-build/{name}"
+    executable_path = test262_path / f"Build/_deps/lagom-build/bin/{name}"
     if not executable_path.exists():
-        executable_path = serenity_path / f"Build/lagom/{name}"
+        executable_path = serenity_path / f"Build/lagom/bin/{name}"
         if not executable_path.exists():
-            executable_path = serenity_path / f"Build/lagom/Meta/Lagom/{name}"
+            executable_path = serenity_path / f"Build/lagom/Meta/Lagom/bin/{name}"
 
     return executable_path
 


### PR DESCRIPTION
This PR updates this repo to use the new ```bin``` subdirectory for SerenityOS binaries, which will land when [#17902](https://github.com/SerenityOS/serenity/pull/17902) gets merged.