### PR TITLE
Do not set address space limit on macOS

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import glob
 import json
 import multiprocessing
 import os
+import platform
 import resource
 import signal
 import subprocess
@@ -82,9 +83,10 @@ def run_streaming_script(
     test_file_paths: list[Path],
 ) -> subprocess.CompletedProcess:
     def limit_memory():
-        resource.setrlimit(
-            resource.RLIMIT_AS, (memory_limit * 1024 * 1024, resource.RLIM_INFINITY)
-        )
+        if platform.system() != "Darwin":
+            resource.setrlimit(
+                resource.RLIMIT_AS, (memory_limit * 1024 * 1024, resource.RLIM_INFINITY)
+            )
 
     command = [
         str(libjs_test262_runner),


### PR DESCRIPTION
First, macOS no longer respects this resource limit anyways (I was not able to find a primary source, but see: https://crbug.com/853873).

More critically, our setrlimit invocation results in an exception raised with EINVAL on macOS. Even in C++, the following fails:

```c++
struct rlimit rl;
rl.rlim_cur = 512 * 1024 * 1024;
rl.rlim_max = RLIM_INFINITY;

int result = setrlimit(RLIMIT_AS, &rl);
// result == EINVAL
```

Resource limits seem to be non-functional on macOS in general; some even require recompiling Python from source to change the limits: https://bugs.python.org/issue40518